### PR TITLE
Add support for Laravel 5.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
       env: ILLUMINATE_VERSION=5.6.*
     - php: 7.1
       env: ILLUMINATE_VERSION=5.7.*
+    - php: 7.1
+      env: ILLUMINATE_VERSION=5.8.*
 
 before_install:
   - if [[ $TRAVIS_PHP_VERSION != 7.1 && $TRAVIS_PHP_VERSION != hhvm ]] ; then phpenv config-rm xdebug.ini; fi

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
     "php": ">=7.0",
     "elasticsearch/elasticsearch": "~5.3.0",
     "ongr/elasticsearch-dsl": "5.*",
-    "illuminate/container": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
-    "illuminate/contracts": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
-    "illuminate/console": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
-    "illuminate/pagination": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
-    "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
-    "illuminate/database": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*"
+    "illuminate/container": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*",
+    "illuminate/contracts": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*",
+    "illuminate/console": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*",
+    "illuminate/pagination": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*",
+    "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*",
+    "illuminate/database": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
Per the `composer.json`, plastic only supports versions of Laravel up to 5.7. This PR adds support for Laravel 5.8

I went through the upgrade guide (https://laravel.com/docs/5.8/upgrade) and verified that all of the code was compatible.